### PR TITLE
Implemented a moving platform

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Box_1x1x1.tscn" type="PackedScene" id=2]
 [ext_resource path="res://materials/green_grid_material.tres" type="Material" id=3]
 [ext_resource path="res://Box_2x2x2.tscn" type="PackedScene" id=4]
 [ext_resource path="res://MovableBox.tscn" type="PackedScene" id=5]
+[ext_resource path="res://Platform.tscn" type="PackedScene" id=6]
 
 [sub_resource type="CubeMesh" id=1]
 size = Vector3( 100, 1, 100 )
@@ -19,7 +20,7 @@ transform = Transform( -1, -1.42109e-14, -3.25841e-07, -2.03072e-07, 0.782043, 0
 shadow_enabled = true
 
 [node name="Player" parent="." instance=ExtResource( 1 )]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.61424, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.61424, 4 )
 
 [node name="Camera" type="Camera" parent="Player"]
 transform = Transform( 1, 0, 0, 0, 0.603083, 0.797679, 0, -0.797679, 0.603083, 0, 2.62919, 2.27578 )
@@ -55,3 +56,19 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 1.5, 1 )
 
 [node name="MovableBox03" parent="Movable objects" instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 2.5, 1 )
+
+[node name="Platform" type="Spatial" parent="."]
+
+[node name="Platform01" parent="Platform" instance=ExtResource( 6 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 0.75, 2 )
+move_to = NodePath("Target")
+
+[node name="Target" type="Position3D" parent="Platform/Platform01"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 0, 0 )
+
+[node name="Platform02" parent="Platform" instance=ExtResource( 6 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, -1 )
+move_to = NodePath("Target")
+
+[node name="Target" type="Position3D" parent="Platform/Platform02"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 5, 0 )

--- a/Platform.gd
+++ b/Platform.gd
@@ -1,0 +1,75 @@
+extends StaticBody
+
+# Small note here, the area collision shape is larger than I'd like because of the way we've implemented our kinematic character
+# It's collision shape starts fairly high.
+# If you implement your own kinematic character with a capsule collision shape you could keep the detection area pretty thin.
+# Also for now we're only checking kinematic characters. 
+# If we want rigid bodies places onto the platform to move as well I guess the same technique could be used. 
+
+export (NodePath) var move_to = null
+export var acceleration = 10.0
+export var slowdown_factor = 0.5
+
+onready var start_position = global_transform.origin
+onready var end_position = global_transform.origin
+
+enum {
+	TARGET_START,
+	TARGET_END
+}
+
+var velocity = Vector3(0.0, 0.0, 0.0)
+var target_pos = Vector3(0.0, 0.0, 0.0)
+var start_or_end = TARGET_END
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	if move_to:
+		var target = get_node(move_to)
+		if target:
+			end_position = target.global_transform.origin
+	
+	target_pos = end_position
+
+func _physics_process(delta):
+	if start_position == end_position:
+		return
+	
+	var current_pos = global_transform.origin
+	var distance_to_target = target_pos - current_pos
+	if distance_to_target.length() < 0.1:
+		# nearly there, lets turn around
+		if start_or_end == TARGET_END:
+			start_or_end = TARGET_START
+			target_pos = start_position
+		else:
+			start_or_end = TARGET_END
+			target_pos = end_position
+		
+		distance_to_target = target_pos - current_pos
+	
+	if distance_to_target.length() < velocity.length() * slowdown_factor:
+		# if after a second we'd overshoot our target, lets decelarate
+		velocity *= clamp(1.0 - (delta * acceleration), 0.0, 1.0)
+	else:
+		# lets accelerate towards our target
+		velocity += distance_to_target.normalized() * delta * acceleration
+	
+	# Who are on the platform?
+	var on_platform = $DetectOnPlatform.get_overlapping_bodies()
+	
+	# How much are we moving?
+	var move = velocity * delta
+	
+	# Should detect if something is in the way here... 
+	
+	# Move our platform
+	global_transform.origin += move
+	
+	# Also move anything on our platform
+	for body in on_platform:
+		if body == self:
+			# don't move ourselves, we've already moved...
+			pass
+		elif body is KinematicBody:
+				body.global_transform.origin += move

--- a/Platform.tscn
+++ b/Platform.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://materials/blue_grid_material.tres" type="Material" id=1]
+[ext_resource path="res://Platform.gd" type="Script" id=2]
+
+[sub_resource type="CubeMesh" id=1]
+size = Vector3( 1, 0.5, 1 )
+
+[sub_resource type="BoxShape" id=2]
+extents = Vector3( 0.5, 0.25, 0.5 )
+
+[sub_resource type="BoxShape" id=3]
+extents = Vector3( 0.5, 0.2, 0.5 )
+
+[node name="Platform01" type="StaticBody"]
+script = ExtResource( 2 )
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+mesh = SubResource( 1 )
+material/0 = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+shape = SubResource( 2 )
+
+[node name="DetectOnPlatform" type="Area" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.25, 0 )
+
+[node name="CollisionShape" type="CollisionShape" parent="DetectOnPlatform"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, 0 )
+shape = SubResource( 3 )

--- a/screenshot.png.import
+++ b/screenshot.png.import
@@ -2,15 +2,15 @@
 
 importer="texture"
 type="StreamTexture"
-path="res://.import/Screenshot.png-4041fbd5caf1794319b3e76676513bf0.stex"
+path="res://.import/screenshot.png-024a21af5d37bf0f0dd0e2bccdd149d0.stex"
 metadata={
 "vram_texture": false
 }
 
 [deps]
 
-source_file="res://Screenshot.png"
-dest_files=[ "res://.import/Screenshot.png-4041fbd5caf1794319b3e76676513bf0.stex" ]
+source_file="res://screenshot.png"
+dest_files=[ "res://.import/screenshot.png-024a21af5d37bf0f0dd0e2bccdd149d0.stex" ]
 
 [params]
 


### PR DESCRIPTION
Implemented a moving platform using an area to detect if the player is on top of the platform and moving the player along with the platform if so.

The area detection collision shape is a little larger than I'd like because of the way I did the kinematic character.

The platform moves to a target node that you assign in its properties. In the example scene I've made this target node a child of the platform. As the location is sampled in _ready the fact the target node moves has no effect on the platform working.

It should be pretty easy to change the logic to make the platform follow a curve/path